### PR TITLE
Add arm support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+/Dockerfile
+/docker-compose.yml
+/golang
+/swift
+/examples
+/.git
+/.github
+/CODE_OF_CONDUCT.md
+/LICENSE
+/logo.png

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM tiangolo/uvicorn-gunicorn-fastapi:python3.8-slim
+FROM python:3.8-slim
 
-# RUN apt-get update \
-#     && apt-get install --yes --no-install-recommends \
-#         build-essential python-dev
+RUN apt-get update \
+&& apt-get install gcc ffmpeg -y \
+&& apt-get clean
 
 EXPOSE 8000
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1


### PR DESCRIPTION
by removing dependance on external image

I also added a `.dockerignore` so the unneeded files aren't copied into `/app`