### PR TITLE
Admit localhost or another docker container in ...upload/by_url

### DIFF
--- a/routers/photo.py
+++ b/routers/photo.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 from pathlib import Path
 import requests
-from pydantic import HttpUrl
+from pydantic import HttpUrl, AnyHttpUrl
 from fastapi import APIRouter, Depends, File, UploadFile, Form
 from fastapi.responses import FileResponse
 from instagrapi.types import (
@@ -143,7 +143,7 @@ async def photo_upload(sessionid: str = Form(...),
 
 @router.post("/upload/by_url", response_model=Media)
 async def photo_upload(sessionid: str = Form(...),
-                       url: HttpUrl = Form(...),
+                       url: AnyHttpUrl = Form(...),
                        caption: str = Form(...),
                        upload_id: Optional[str] = Form(""),
                        usertags: Optional[List[Usertag]] = Form([]),
@@ -154,8 +154,6 @@ async def photo_upload(sessionid: str = Form(...),
     """
     cl = clients.get(sessionid)
     content = requests.get(url).content
-    print(url)
-    print(content)
     return await photo_upload_post(
         cl, content, caption=caption,
         upload_id=upload_id,

--- a/routers/photo.py
+++ b/routers/photo.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 from pathlib import Path
 import requests
-from pydantic import HttpUrl, AnyHttpUrl
+from pydantic import AnyHttpUrl
 from fastapi import APIRouter, Depends, File, UploadFile, Form
 from fastapi.responses import FileResponse
 from instagrapi.types import (
@@ -56,7 +56,7 @@ async def photo_upload_to_story(sessionid: str = Form(...),
 
 @router.post("/upload_to_story/by_url", response_model=Story)
 async def photo_upload_to_story_by_url(sessionid: str = Form(...),
-                                url: HttpUrl = Form(...),
+                                url: AnyHttpUrl = Form(...),
                                 as_video: Optional[bool] = Form(False),
                                 caption: Optional[str] = Form(""),
                                 mentions: Optional[List[StoryMention]] = Form([]),

--- a/routers/photo.py
+++ b/routers/photo.py
@@ -154,6 +154,8 @@ async def photo_upload(sessionid: str = Form(...),
     """
     cl = clients.get(sessionid)
     content = requests.get(url).content
+    print(url)
+    print(content)
     return await photo_upload_post(
         cl, content, caption=caption,
         upload_id=upload_id,

--- a/routers/video.py
+++ b/routers/video.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 from pathlib import Path
 import requests
-from pydantic import HttpUrl
+from pydantic import AnyHttpUrl
 from fastapi.responses import FileResponse
 from fastapi import APIRouter, Depends, File, UploadFile, Form
 from instagrapi.types import (
@@ -48,7 +48,7 @@ async def video_upload_to_story(sessionid: str = Form(...),
 
 @router.post("/upload_to_story/by_url", response_model=Story)
 async def video_upload_to_story_by_url(sessionid: str = Form(...),
-                                       url: HttpUrl = Form(...),
+                                       url: AnyHttpUrl = Form(...),
                                        caption: Optional[str] = Form(''),
                                        mentions: List[StoryMention] = [],
                                        locations: List[StoryLocation] = [],


### PR DESCRIPTION
This is to solve a bug when passing to the api a local url.
(See this issue https://github.com/tiangolo/fastapi/issues/2560)

Example urls: http://localhost/public/... or http://docker-container:port/public/...

Message from fast-api:  "msg": "URL host invalid, top level domain required"