### PR TITLE
docs: redirect Telegram links to @aiograpi_support

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-https://t.me/instagrapi.
+https://t.me/aiograpi_support.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is the cross-language exit when your stack is not Python and the maintained Instagram libraries in your own language have gone stale or been archived (which, as of 2026, is most of them — see the [language-by-language survey](https://instagrapi.com/guides/instagram-api-libraries-by-language) on instagrapi.com).
 
-[Support chat on Telegram](https://t.me/instagrapi)
+Support chat on Telegram: https://t.me/aiograpi_support (the previous `@instagrapi` group was restricted by Meta and is no longer maintained)
 
 ## Why this exists
 


### PR DESCRIPTION
## Summary

The `@instagrapi` Telegram group has been restricted by a Meta copyright takedown — group settings are frozen and messages are no longer delivered. Point users at https://t.me/aiograpi_support, the new joint support chat for instagrapi / aiograpi / instagrapi-rest.

- **README**: replace the support-chat link
- **CODE_OF_CONDUCT.md**: update enforcement contact

## Test plan

- [x] Diff inspected — only links changed
- [ ] After merge: confirm README renders correctly on GitHub